### PR TITLE
Copy changes for launch

### DIFF
--- a/src/components/ArrowLink.js
+++ b/src/components/ArrowLink.js
@@ -14,7 +14,7 @@ export function BackButton(props) {
 
 BackButton.defaultProps = {
   to: '/',
-  children: 'DevHub'
+  children: 'Home'
 };
 
 export default function ArrowLink({direction, ...props}) {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -55,7 +55,7 @@ export default function Header() {
           textTransform="uppercase"
           letterSpacing="widest"
         >
-          DevHub
+          Developers
         </Box>
       </Flex>
       <Search {...searchProps} />
@@ -73,7 +73,7 @@ export default function Header() {
         />
         <MenuList>
           <MenuItem as={GatsbyLink} to="/">
-            DevHub
+            Home
           </MenuItem>
           <MenuItem as="a" href="https://www.apollographql.com/docs">
             Docs
@@ -99,7 +99,7 @@ export default function Header() {
         spacing="8"
       >
         <Link as={GatsbyLink} to="/" color="indigo.600">
-          DevHub
+          Home
         </Link>
         <div>
           <Menu placement="bottom">

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -17,7 +17,10 @@ export default function Layout({children}) {
       }}
       backgroundRepeat="no-repeat"
     >
-      <Helmet defaultTitle="DevHub" titleTemplate="%s - DevHub">
+      <Helmet
+        defaultTitle="Apollo Developer Hub"
+        titleTemplate="%s - Apollo Developer Hub"
+      >
         <link rel="icon" href="https://www.apollographql.com/favicon.ico" />
       </Helmet>
       <Header />

--- a/src/pages/collections.js
+++ b/src/pages/collections.js
@@ -24,7 +24,7 @@ FilterTag.propTypes = {
 };
 
 const DESCRIPTION =
-  'Collections are groups of articles, videos, and tutorials about a particular topic.';
+  "Looking for resources on federation, caching, or learning Apollo? We've grouped our favorite posts, videos, tutorials, and docs into collections to help you solve common GraphQL challenges.";
 
 export default function Collections({data}) {
   const [filter, setFilter] = useState({});
@@ -38,10 +38,7 @@ export default function Collections({data}) {
           <Heading mb="4" fontSize={{base: '3xl', md: '4xl'}}>
             Apollo Collections
           </Heading>
-          <Text fontSize={{md: 'lg'}}>
-            {DESCRIPTION} They are regularly updated with the most recent and
-            relevant content available.
-          </Text>
+          <Text fontSize={{md: 'lg'}}>{DESCRIPTION}</Text>
         </Box>
         <Wrap mb={{base: 12, md: 16}}>
           <span>Filter:</span>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -116,7 +116,7 @@ export default function HomePage({data, location}) {
               })}
             </List>
             <ArrowLink to="/feed/1" direction="right">
-              See the full feed
+              Learn what&#39;s new
             </ArrowLink>
           </div>
         </Grid>
@@ -131,10 +131,11 @@ export default function HomePage({data, location}) {
             <a href="#collections">Apollo Collections</a>
           </Heading>
           <Text mb="6" fontSize={{md: 'lg'}}>
-            Hand-picked blog posts, videos, and documentation.
+            Hand-picked lists of essential posts, videos, tutorials, and docs to
+            help you learn GraphQL and Apollo.
           </Text>
           <ArrowLink direction="right" to="/collections">
-            See all of our collections
+            Explore all collections
           </ArrowLink>
         </Box>
       </Container>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,9 +25,9 @@ import {
 } from '../utils';
 import {graphql} from 'gatsby';
 
-const TITLE = 'Welcome to DevHub';
+const TITLE = 'Apollo Developer Hub';
 const DESCRIPTION =
-  'Explore all the latest resources for building apps with Apollo.';
+  'An Apollo data graph helps you build apps faster with less code. Learn how to write your first GraphQL query or build a production graph with our curated resources.';
 
 export default function HomePage({data, location}) {
   const [featuredPost, ...posts] = combinePosts(data).slice(0, 5);

--- a/src/templates/feed.js
+++ b/src/templates/feed.js
@@ -9,8 +9,9 @@ import {CONTAINER_PADDING_X, combinePosts} from '../utils';
 import {Link as GatsbyLink, graphql} from 'gatsby';
 
 const MAX_PAGES_SHOWN = 9;
-const TITLE = 'News Feed';
-const DESCRIPTION = 'This timeline highlights activity across all of Apollo.';
+const TITLE = "What's new in Apollo";
+const DESCRIPTION =
+  'Stay in our orbit with product updates, events, blog posts, and community news.';
 
 export default function FeedTemplate({data, pageContext}) {
   const posts = combinePosts(data);
@@ -32,11 +33,7 @@ export default function FeedTemplate({data, pageContext}) {
           <Heading mb="4" fontSize={{base: '3xl', md: '4xl'}}>
             {TITLE}
           </Heading>
-          <Text fontSize={{md: 'lg'}}>
-            {DESCRIPTION} It includes product updates, announcements, and
-            educational content from both our team and the larger Apollo
-            community.
-          </Text>
+          <Text fontSize={{md: 'lg'}}>{DESCRIPTION}</Text>
         </Box>
         <FeedTable posts={posts} swapDate showDescription />
         <Box mt="16">


### PR DESCRIPTION
Made some copy changes:
- Removed "DevHub" references --> changed to Apollo Developer Hub
- Copy changes for homepage, collections, and feed

Stuff I didn't get to:
- Link to Learning GraphQL & Production Graph collections in the copy under the Apollo Developer Hub header on the homepage (need to add the collection + update the slugs first)
- Add dropdown to Home in navbar with links to the News Feed and Collections pages

cc @trevorblades @StephenBarlow 