### PR TITLE
Update events nav link

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Search from './Search';
-import {ApolloIcon} from '@apollo/space-kit/icons/ApolloIcon';
+import { ApolloIcon } from '@apollo/space-kit/icons/ApolloIcon';
 import {
   Box,
   Button,
@@ -16,11 +16,11 @@ import {
   MenuList,
   useDisclosure
 } from '@chakra-ui/core';
-import {Link as GatsbyLink} from 'gatsby';
-import {IconArrowDown} from '@apollo/space-kit/icons/IconArrowDown';
-import {IconMenu} from '@apollo/space-kit/icons/IconMenu';
+import { Link as GatsbyLink } from 'gatsby';
+import { IconArrowDown } from '@apollo/space-kit/icons/IconArrowDown';
+import { IconMenu } from '@apollo/space-kit/icons/IconMenu';
 
-function NavMenu({children, label, ...props}) {
+function NavMenu({ children, label, ...props }) {
   return (
     <Menu placement="bottom">
       <MenuButton fontWeight="inherit" {...props}>
@@ -106,7 +106,7 @@ export default function Header() {
           <MenuItem as="a" href="https://www.apollographql.com/blog">
             Blog
           </MenuItem>
-          <MenuItem as="a" href="https://go.apollo.dev/events-calendar">
+          <MenuItem as="a" href="https://apollographql.com/events">
             Events
           </MenuItem>
           <MenuItem as="a" href="https://studio.apollographql.com">


### PR DESCRIPTION
This PR updates the events nav link to point to the new events hub on ApollGraphQL.com.