### PR TITLE
Update gtm container id & remove unified ga4 property

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -80,10 +80,7 @@ module.exports = {
       resolve: 'gatsby-plugin-google-gtag',
       options: {
         // You can add multiple tracking ids and a pageview event will be fired for all of them.
-        trackingIds: [
-          'UA-74643563-17', // devhub specific property tracking
-          'G-0BGG5V2W2K' // Unified GA4 tracking
-        ],
+        trackingIds: ['UA-74643563-17'],
         // This object gets passed directly to the gtag config command
         // This config will be shared across all trackingIds
         gtagConfig: {


### PR DESCRIPTION
This PR updates the GTM container ID & removes the unified ga4 property as it's been moved into the new GTM container.